### PR TITLE
feat(season): only load seasons using the set audio language

### DIFF
--- a/server/js/core/mappers/crunchyroll.js
+++ b/server/js/core/mappers/crunchyroll.js
@@ -99,7 +99,17 @@ window.mapper = {
   },
 
   seasons: function (response) {
-    return response.items.map((season) => ({
+    return response.items
+      .filter((season) => {
+        var is_audio_match =
+          season.audio_locale === session.storage.account.audio ||
+          season.audio_locales.includes(session.storage.account.audio);
+        var has_audio_match = season.versions.some(
+          (version) => version.audio_locale === session.storage.account.audio,
+        );
+        return is_audio_match || (!season.is_dubbed && !has_audio_match);
+      })
+      .map((season) => ({
       id: season.id,
       title: season.title,
       number: season.season_number,


### PR DESCRIPTION
feat(season): include original audio version if preferred audio lang is not available

Often times, in shows with many dubs, there are too many duplicates of the same season. This change more closely replicates how Crunchyroll works in their main apps by only showing seasons that match the user's audio language (or the undubbed/original language if the user's language is unavailable).