### PR TITLE
feat(season): only show season names; remove season numbers

### DIFF
--- a/server/js/screen/home.episodes.js
+++ b/server/js/screen/home.episodes.js
@@ -36,9 +36,7 @@ window.home_episodes = {
         var seasons_html = "";
         home_episodes.data.seasons.forEach((season, index) => {
           seasons_html += `
-          <div class="season${index === 0 ? " selected active" : ""}">${
-            season.number
-          }. ${season.title}</div>`;
+          <div class="season${index === 0 ? " selected active" : ""}">${season.title}</div>`;
         });
         $(".seasons #seasons-list-offset").eq(0).html(seasons_html);
         home_episodes.load(home_episodes.data.seasons[0]);
@@ -56,7 +54,7 @@ window.home_episodes = {
   },
 
   load: function (season) {
-    $(".episodes .title")[0].innerText = `${season.number}. ${season.title}`;
+    $(".episodes .title")[0].innerText = `${season.title}`;
     $(".episodes .episodes-list")[0].slick &&
       $(".episodes .episodes-list")[0].slick.destroy();
     $(".episodes .episodes-list")[0].innerHTML = "";


### PR DESCRIPTION
Sometimes, when a show has in-between seasons, the internal numbering of a season can become out-of-sync with the show's actual numbering of the season. Only showing the season names ensures they're never out of sync.

Example:
<img width="2471" height="1493" alt="image" src="https://github.com/user-attachments/assets/196fdf00-b3cf-4f0a-befb-644b58ec2eba" />
Even though it's season 3, the internal season numbering says season 4. Only showcasing the names avoids that mismatch, as shown below.
<img width="2471" height="1493" alt="image" src="https://github.com/user-attachments/assets/65a9f0d6-c718-43d3-9c3c-9c4b81e6e262" />
