### PR TITLE
feat(episodes): hide premium crown if user has premium

### DIFF
--- a/server/js/screen/home.episodes.js
+++ b/server/js/screen/home.episodes.js
@@ -129,7 +129,9 @@ window.home_episodes = {
   },
 
   premium: function (episode) {
-    return episode.premium ? `<i class="fa-solid fa-crown premium"></i>` : "";
+    return !session.storage.account.premium && episode.premium
+      ? `<i class="fa-solid fa-crown premium"></i>`
+      : "";
   },
 
   destroy: function () {


### PR DESCRIPTION
In official Crunchyroll apps, when a user pays for premium, the app no longer distinguishes premium-only episodes. From a design standpoint, it makes sense. After all, users might get confused, thinking that certain episodes are gated from them, even if they have premium.

So, this change just tries to replicate that behavior. It hides the premium crown on episodes, if the user has premium.