### PR TITLE
feat(logout): move logout to settings, instead of main menu

### DIFF
--- a/server/js/core/languages.js
+++ b/server/js/core/languages.js
@@ -22,7 +22,6 @@ window.languages = {
       history: "इतिहास",
       browse: "ब्राउज़ करें",
       settings: "सेटिंग्स",
-      logout: "लॉगआउट",
     },
     home: {
       banner: {
@@ -68,6 +67,7 @@ window.languages = {
         video_quality: "वीडियो गुणवत्ता",
         mature: "परिपक्व सामग्री",
         about: "के बारे में",
+        logout: "लॉगआउट",
       },
     },
     lists: {
@@ -102,7 +102,6 @@ window.languages = {
       history: "التاريخ",
       browse: "تصفح",
       settings: "الإعدادات",
-      logout: "تسجيل الخروج",
     },
     home: {
       banner: {
@@ -147,6 +146,7 @@ window.languages = {
         video_quality: "جودة الفيديو",
         mature: "محتوى للبالغين",
         about: "حول",
+        logout: "تسجيل الخروج",
       },
     },
     lists: {
@@ -181,7 +181,6 @@ window.languages = {
       history: "Historial",
       browse: "Navega",
       settings: "Configuració",
-      logout: "Tanca la sessió",
     },
     home: {
       banner: {
@@ -226,6 +225,7 @@ window.languages = {
         video_quality: "Qualitat del vídeo",
         mature: "Contingut per a adults",
         about: "Sobre",
+        logout: "Tanca la sessió",
       },
     },
     lists: {
@@ -260,7 +260,6 @@ window.languages = {
       history: "Verlauf",
       browse: "Durchsuchen",
       settings: "Einstellungen",
-      logout: "Abmelden",
     },
     home: {
       banner: {
@@ -305,6 +304,7 @@ window.languages = {
         video_quality: "Videoqualität",
         mature: "Erwachseneninhalt",
         about: "Über",
+        logout: "Abmelden",
       },
     },
     lists: {
@@ -339,7 +339,6 @@ window.languages = {
       profiles: "Profiles",
       controller: "Game Controller",
       settings: "Settings",
-      logout: "Logout",
     },
     home: {
       banner: {
@@ -384,6 +383,7 @@ window.languages = {
         video_quality: "Video Quality",
         mature: "Mature Content",
         about: "About",
+        logout: "Logout",
       },
     },
     lists: {
@@ -418,7 +418,6 @@ window.languages = {
       history: "Historial",
       browse: "Explorar",
       settings: "Configuración",
-      logout: "Cerrar sesión",
     },
     home: {
       banner: {
@@ -463,6 +462,7 @@ window.languages = {
         video_quality: "Calidad del video",
         mature: "Contenido para adultos",
         about: "Acerca de",
+        logout: "Cerrar sesión",
       },
     },
     lists: {
@@ -497,7 +497,6 @@ window.languages = {
       history: "Historique",
       browse: "Explorer",
       settings: "Paramètres",
-      logout: "Déconnexion",
     },
     home: {
       banner: {
@@ -542,6 +541,7 @@ window.languages = {
         video_quality: "Qualité de la vidéo",
         mature: "Contenu pour adultes",
         about: "À propos de",
+        logout: "Déconnexion",
       },
     },
     lists: {
@@ -576,7 +576,6 @@ window.languages = {
       history: "Riwayat",
       browse: "Jelajah",
       settings: "Pengaturan",
-      logout: "Keluar",
     },
     home: {
       banner: {
@@ -621,6 +620,7 @@ window.languages = {
         video_quality: "Kualitas Video",
         mature: "Konten Dewasa",
         about: "Tentang",
+        logout: "Keluar",
       },
     },
     lists: {
@@ -655,7 +655,6 @@ window.languages = {
       history: "Cronologia",
       browse: "Esplora",
       settings: "Impostazioni",
-      logout: "Esci",
     },
     home: {
       banner: {
@@ -700,6 +699,7 @@ window.languages = {
         video_quality: "Qualità del video",
         mature: "Contenuti per adulti",
         about: "Informazioni",
+        logout: "Esci",
       },
     },
     lists: {
@@ -734,7 +734,6 @@ window.languages = {
       history: "Sejarah",
       browse: "Jelajah",
       settings: "Tetapan",
-      logout: "Log Keluar",
     },
     home: {
       banner: {
@@ -779,6 +778,7 @@ window.languages = {
         video_quality: "Kualiti Video",
         mature: "Kandungan Dewasa",
         about: "Mengenai",
+        logout: "Log Keluar",
       },
     },
     lists: {
@@ -813,7 +813,6 @@ window.languages = {
       history: "Historia",
       browse: "Przeglądaj",
       settings: "Ustawienia",
-      logout: "Wyloguj",
     },
     home: {
       banner: {
@@ -858,6 +857,7 @@ window.languages = {
         video_quality: "Jakość wideo",
         mature: "Zawartość dla dorosłych",
         about: "O nas",
+        logout: "Wyloguj",
       },
     },
     lists: {
@@ -892,7 +892,6 @@ window.languages = {
       history: "Histórico",
       browse: "Navegar",
       settings: "Configurações",
-      logout: "Sair",
     },
     home: {
       banner: {
@@ -937,6 +936,7 @@ window.languages = {
         video_quality: "Qualidade do vídeo",
         mature: "Conteúdo adulto",
         about: "Sobre",
+        logout: "Sair",
       },
     },
     lists: {
@@ -971,7 +971,6 @@ window.languages = {
       history: "История",
       browse: "Просмотр",
       settings: "Настройки",
-      logout: "Выйти",
     },
     home: {
       banner: {
@@ -1016,6 +1015,7 @@ window.languages = {
         video_quality: "Качество видео",
         mature: "Контент для взрослых",
         about: "О приложении",
+        logout: "Выйти",
       },
     },
     lists: {
@@ -1050,7 +1050,6 @@ window.languages = {
       history: "ประวัติ",
       browse: "เรียกดู",
       settings: "ตั้งค่า",
-      logout: "ออกจากระบบ",
     },
     home: {
       banner: {
@@ -1095,6 +1094,7 @@ window.languages = {
         video_quality: "คุณภาพวิดีโอ",
         mature: "เนื้อหาสำหรับผู้ใหญ่",
         about: "เกี่ยวกับ",
+        logout: "ออกจากระบบ",
       },
     },
     lists: {
@@ -1129,7 +1129,6 @@ window.languages = {
       history: "Geçmiş",
       browse: "Gözat",
       settings: "Ayarlar",
-      logout: "Çıkış",
     },
     home: {
       banner: {
@@ -1174,6 +1173,7 @@ window.languages = {
         video_quality: "Video Kalitesi",
         mature: "Olgun İçerik",
         about: "Hakkında",
+        logout: "Çıkış",
       },
     },
     lists: {
@@ -1208,7 +1208,6 @@ window.languages = {
       history: "Lịch sử",
       browse: "Duyệt",
       settings: "Cài đặt",
-      logout: "Đăng xuất",
     },
     home: {
       banner: {
@@ -1253,6 +1252,7 @@ window.languages = {
         video_quality: "Chất lượng video",
         mature: "Nội dung dành cho người trưởng thành",
         about: "Về ứng dụng",
+        logout: "Đăng xuất",
       },
     },
     lists: {

--- a/server/js/main.js
+++ b/server/js/main.js
@@ -44,21 +44,6 @@ window.main = {
   },
 
   events: {
-    logout: function () {
-      if (document.getElementById(menu.id) != null) menu.destroy();
-
-      var current_id = main.state.replace("-screen", "");
-      if (window[current_id] === undefined) {
-        console.log("Failed to find ID of current screen");
-        menu.init();
-        return;
-      }
-      if (document.getElementById(main.state) != null)
-        window[current_id].destroy();
-      session.clear();
-      login.init();
-    },
-
     login: function () {
       session.valid({
         success: function () {

--- a/server/js/screen/menu.js
+++ b/server/js/screen/menu.js
@@ -46,13 +46,6 @@ window.menu = {
       tool: true,
       action: "settings.init",
     },
-    {
-      id: "logout",
-      label: "menu.logout",
-      icon: "fa-solid fa-sign-out",
-      tool: true,
-      event: "logout",
-    },
   ],
   selected: 2,
   previous: NaN,

--- a/server/js/screen/settings.js
+++ b/server/js/screen/settings.js
@@ -39,6 +39,11 @@ window.settings = {
       label: "settings.menu.about",
       type: "html",
     },
+    {
+      id: "logout",
+      label: "settings.menu.logout",
+      type: "list"
+    },
   ],
   qualities: {
     auto: "Auto",
@@ -57,6 +62,9 @@ window.settings = {
     ENABLE: "Enable Game Controller Support",
   },
   previous: NaN,
+  get logoutOptions() {
+    return {no: `${translate.go("exit.no")}`, yes: `${translate.go("exit.yes")}`};
+  },
 
   init: function () {
     var settings_element = document.createElement("div");
@@ -210,6 +218,10 @@ window.settings = {
             var options = settings.controllerSupport;
             var active = window.localStorage.getItem(CONTROLLER_KEY);
             break;
+          case "logout":
+            var options = settings.logoutOptions;
+            var active = "no";
+            break;
         }
 
         return (
@@ -327,6 +339,26 @@ window.settings = {
                 window.setControllerEnabled(value === "ENABLE");
               session.update();
             };
+            break;
+          case "logout":
+            var options = settings.logoutOptions;
+            method = function (value) {
+              if (value === "yes") {
+                if (document.getElementById(menu.id) != null) menu.destroy();
+
+                var current_id = main.state.replace("-screen", "");
+                if (window[current_id] === undefined) {
+                  console.log("Failed to find ID of current screen");
+                  menu.init();
+                  return;
+                }
+                if (document.getElementById(main.state) != null)
+                  window[current_id].destroy();
+                session.clear();
+                login.init();
+              }
+            };
+            break;
         }
         method(Object.keys(options)[index]);
         optionsMenu.removeClass("active");


### PR DESCRIPTION
On more than a few occasions, I've accidentally logged myself out a session, which forces me to re-enter my credentials to get back in. So, this change strives to make it harder for the user to log themselves out.

Instead of the main menu, the user has navigate to the bottom of the settings menu to find the logout prompt. The user must then press "yes" in their language to logout.

Admittedly, I do have a couple of gripes with my current implementation. For one, I dislike how the "no" option looks when it's selected. Like the other settings option lists, it toggles(?) the "no" option, as if it's saved in the session. I chose to keep it that way, though, because I wanted to reuse working code, rather than creating potentially buggy code.

Secondly, I think that the "Logout" option looks out-of-place next to the other options. The separator ends at the bottom of "About", so "Logout" looks like a tacked-on afterthought. Ideally, they'd look more cohesive with tighter spacing, a scroll bar, or even just shifting the options up a little. But I'm open to whatever works.

<img width="1310" height="719" alt="image" src="https://github.com/user-attachments/assets/9c219e9a-a235-4fb2-8c0a-c40db92dfc7e" />